### PR TITLE
Allow null as value to represent no values for optionals in spray-json formatter

### DIFF
--- a/src/main/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonReadSupport.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonReadSupport.scala
@@ -10,6 +10,7 @@ private[json] object SprayJsonReadSupport {
   implicit class RichJsObject(val obj: JsObject) extends AnyVal {
     def fieldOpt(fieldName: String): Option[JsValue] =
       obj.getFields(fieldName).toList match {
+        case Seq(JsNull) ⇒ None
         case Seq(value) ⇒ Some(value)
         case _ ⇒ None
       }

--- a/src/test/scala/org/zalando/jsonapi/json/JsonBaseSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/JsonBaseSpec.scala
@@ -44,6 +44,9 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
 
   protected lazy val resourceObjectWithEmptyRelationshipsJson = parseJson(resourceObjectWithEmptyRelationshipsJsonString)
 
+  protected lazy val resourceObjectWithNullRelationshipJson = parseJson(resourceObjectWithNullRelationshipJsonString)
+
+
   protected lazy val attributesJsonString =
     """
       |{
@@ -627,6 +630,35 @@ trait JsonBaseSpec[JsonBaseType] extends WordSpec {
     ResourceObjects(List(
       ResourceObject(
         `type` = "person",
+        attributes = Some(List(Attribute("name", StringValue("foobar")))),
+        relationships = Some(Map("father" -> Relationship()))
+      )
+    ))
+  ))
+
+  protected lazy val resourceObjectWithNullRelationshipJsonString =
+    """
+      |{
+      |  "data": [{
+      |    "type": "person",
+      |    "id": "1234",
+      |    "attributes": {
+      |      "name": "foobar"
+      |    },
+      |    "relationships": {
+      |      "father": {
+      |        "data": null
+      |      }
+      |    }
+      |  }]
+      |}
+    """.stripMargin
+
+  protected lazy val resourceObjectWithNullRelationshipObject = RootObject(Some(
+    ResourceObjects(List(
+      ResourceObject(
+        `type` = "person",
+        id = Some("1234"),
         attributes = Some(List(Attribute("name", StringValue("foobar")))),
         relationships = Some(Map("father" -> Relationship()))
       )

--- a/src/test/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonJsonapiFormatSpec.scala
+++ b/src/test/scala/org/zalando/jsonapi/json/sprayjson/SprayJsonJsonapiFormatSpec.scala
@@ -109,6 +109,9 @@ class SprayJsonJsonapiFormatSpec extends JsonBaseSpec[JsValue] with MustMatchers
       "transform empty relationship object correctly" in {
         resourceObjectWithEmptyRelationshipsJson.convertTo[RootObject] === resourceObjectWithEmptyRelationshipsObject
       }
+      "transform null relationship object correctly" in {
+        resourceObjectWithNullRelationshipJson.convertTo[RootObject] === resourceObjectWithNullRelationshipObject
+      }
       "fail if data is not an array nor an object" in {
         val json = s"""{"data": "foo"}""".parseJson
         intercept[DeserializationException] {


### PR DESCRIPTION
This pull request fixes issue #94