### PR TITLE
upgrade dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,23 +12,22 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= {
-  val circeVersion    = "0.7.1"
+  val circeVersion    = "0.11.0"
   val akkaVersion     = "2.4.20"
-  val akkaHttpVersion = "2.4.11.2"
+  val akkaHttpVersion = "10.0.14"
   val sprayVersion    = "1.3.4"
 
   Seq(
     "io.spray"          %% "spray-json"             % sprayVersion    % "provided",
     "io.spray"          %% "spray-httpx"            % sprayVersion    % "provided",
     "com.typesafe.akka" %% "akka-actor"             % akkaVersion     % "provided",
-    "com.typesafe.akka" %% "akka-http-core"         % akkaHttpVersion % "provided",
-    "com.typesafe.akka" %% "akka-http-experimental" % akkaHttpVersion % "provided",
-    "com.typesafe.play" %% "play-json"              % "2.3.10"        % "provided",
+    "com.typesafe.akka" %% "akka-http"              % akkaHttpVersion % "provided",
+    "com.typesafe.play" %% "play-json"              % "2.6.11"        % "provided",
     "io.circe"          %% "circe-core"             % circeVersion    % "provided",
     "io.circe"          %% "circe-generic"          % circeVersion    % "provided",
     "io.circe"          %% "circe-parser"           % circeVersion    % "provided",
-    "org.scalatest"     %% "scalatest"              % "3.0.5"         % "test",
-    "com.typesafe.akka" %% "akka-http-testkit"      % akkaHttpVersion % "test"
+    "org.scalatest"     %% "scalatest"              % "3.0.6-SNAP5"   % Test,
+    "com.typesafe.akka" %% "akka-http-testkit"      % akkaHttpVersion % Test
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0-M5")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.2.12")
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")

--- a/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiFormat.scala
@@ -276,37 +276,37 @@ trait PlayJsonJsonapiFormat {
           keyValue match {
             case (FieldNames.`about`, JsString(u)) ⇒ Links.About(u, None)
             case (FieldNames.`about`, JsObject(linkObjectJson)) =>
-              val linkValues = jsonToLinkValues(linkObjectJson)
+              val linkValues = jsonToLinkValues(linkObjectJson.toSeq)
               Links.About(linkValues._1, linkValues._2)
 
             case (FieldNames.`first`, JsString(u)) ⇒ Links.First(u, None)
             case (FieldNames.`first`, JsObject(linkObjectJson)) =>
-              val linkValues = jsonToLinkValues(linkObjectJson)
+              val linkValues = jsonToLinkValues(linkObjectJson.toSeq)
               Links.First(linkValues._1, linkValues._2)
 
             case (FieldNames.`last`, JsString(u)) ⇒ Links.Last(u, None)
             case (FieldNames.`last`, JsObject(linkObjectJson)) =>
-              val linkValues = jsonToLinkValues(linkObjectJson)
+              val linkValues = jsonToLinkValues(linkObjectJson.toSeq)
               Links.Last(linkValues._1, linkValues._2)
 
             case (FieldNames.`next`, JsString(u)) ⇒ Links.Next(u, None)
             case (FieldNames.`next`, JsObject(linkObjectJson)) =>
-              val linkValues = jsonToLinkValues(linkObjectJson)
+              val linkValues = jsonToLinkValues(linkObjectJson.toSeq)
               Links.Next(linkValues._1, linkValues._2)
 
             case (FieldNames.`prev`, JsString(u)) ⇒ Links.Prev(u, None)
             case (FieldNames.`prev`, JsObject(linkObjectJson)) =>
-              val linkValues = jsonToLinkValues(linkObjectJson)
+              val linkValues = jsonToLinkValues(linkObjectJson.toSeq)
               Links.Prev(linkValues._1, linkValues._2)
 
             case (FieldNames.`related`, JsString(u)) ⇒ Links.Related(u, None)
             case (FieldNames.`related`, JsObject(linkObjectJson)) =>
-              val linkValues = jsonToLinkValues(linkObjectJson)
+              val linkValues = jsonToLinkValues(linkObjectJson.toSeq)
               Links.Related(linkValues._1, linkValues._2)
 
             case (FieldNames.`self`, JsString(u)) ⇒ Links.Self(u, None)
             case (FieldNames.`self`, JsObject(linkObjectJson)) =>
-              val linkValues = jsonToLinkValues(linkObjectJson)
+              val linkValues = jsonToLinkValues(linkObjectJson.toSeq)
               Links.Self(linkValues._1, linkValues._2)
           }
         }.toVector)

--- a/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiSupport.scala
+++ b/src/main/scala/org/zalando/jsonapi/json/playjson/PlayJsonJsonapiSupport.scala
@@ -13,7 +13,7 @@ trait PlayJsonapiSupport {
   implicit def playJsonUnmarshaller[T: Reads] =
     delegate[String, T](`application/json`, `application/vnd.api+json`)(string ⇒
       try {
-        implicitly[Reads[T]].reads(Json.parse(string)).asEither.left.map(e ⇒ MalformedContent(s"Received JSON is not valid.\n${Json.prettyPrint(JsError.toFlatJson(e))}"))
+        implicitly[Reads[T]].reads(Json.parse(string)).asEither.left.map(e ⇒ MalformedContent(s"Received JSON is not valid.\n${Json.prettyPrint(JsError.toJson(e))}"))
       } catch {
         case NonFatal(exc) ⇒ Left(MalformedContent(exc.getMessage, exc))
       })(UTF8StringUnmarshaller)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.3"
+version in ThisBuild := "0.7.0-SNAPSHOT"


### PR DESCRIPTION
* upgrades sbt and sbt plugins to latest versions
* upgrades jar dependencies that don't lead to build issues

An initial step towards supporting Scala 2.12.
Spray-httpx is not supported in Scala 2.12 - full Scala 2.12 support will require replacing those classes with the Akka-Http equivalents.